### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -11,7 +11,7 @@ runs:
         java-version: ${{ env.JAVA_VERSION }}
 
     - name: Setup Android SDK
-      uses: android-actions/setup-android@v3
+      uses: android-actions/setup-android@v4
 
     - name: Install NDK
       run: sdkmanager "ndk;${{ env.NDK_VERSION }}"

--- a/.github/actions/setup-js/action.yaml
+++ b/.github/actions/setup-js/action.yaml
@@ -4,8 +4,8 @@ description: "Setup JavaScript dependencies"
 runs:
   using: "composite"
   steps:
-    - uses: pnpm/action-setup@v4
-    - uses: actions/setup-node@v5
+    - uses: pnpm/action-setup@v5
+    - uses: actions/setup-node@v6
       with:
         node-version: lts/*
     - run: pnpm install --frozen-lockfile

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -18,7 +18,7 @@ jobs:
     name: Audit dependencies
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-js
       - run: pnpm audit --prod
 
@@ -27,7 +27,7 @@ jobs:
     needs: audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-js
       - run: pnpm run check
 
@@ -36,7 +36,7 @@ jobs:
     needs: audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-js
       - run: pnpm test
 
@@ -47,18 +47,18 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-js
       - uses: ./.github/actions/build
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
-          name: android-app-apk
+          archive: false
           if-no-files-found: error
           path: src-tauri/gen/android/app/build/outputs/apk/universal/release/app-universal-release.apk
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
-          name: android-app-bundle
+          archive: false
           if-no-files-found: error
           path: src-tauri/gen/android/app/build/outputs/bundle/universalRelease/app-universal-release.aab

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,13 +30,13 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ secrets.HNR_GH_APP_ID }}
           private-key: ${{ secrets.HNR_GH_APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
           ref: main
@@ -74,7 +74,7 @@ jobs:
         run: git push origin HEAD:main --follow-tags
 
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           name: "Hungry Noodle ${{ env.TAGGED_VERSION }}"
           tag_name: ${{ env.TAGGED_VERSION }}


### PR DESCRIPTION
- Upgrade android-actions/setup-android from v3 to v4
- Upgrade pnpm/action-setup from v4 to v5
- Upgrade actions/setup-node from v5 to v6
- Upgrade actions/checkout from v5 to v6
- Upgrade actions/upload-artifact from v4 to v7
- Upgrade actions/create-github-app-token from v2 to v3
- Upgrade softprops/action-gh-release from v2 to v3