### PR TITLE
feat(progression): add High Scores screen at /progression/high-scores

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -15,12 +15,19 @@ export const routes: Routes = [
     path: "play",
     loadComponent: () => import("./components/play/play").then((m) => m.Play),
   },
-  // Placeholder routes for future implementation
   {
     path: "progression",
-    loadComponent: () =>
-      import("./components/main-menu/main-menu").then((m) => m.MainMenu), // Temporary redirect
+    redirectTo: "/progression/high-scores",
+    pathMatch: "full",
   },
+  {
+    path: "progression/high-scores",
+    loadComponent: () =>
+      import("./components/progression/high-scores/high-scores").then(
+        (m) => m.HighScores,
+      ),
+  },
+  // Placeholder routes for future implementation
   {
     path: "shop",
     loadComponent: () =>

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -17,11 +17,6 @@ export const routes: Routes = [
   },
   {
     path: "progression",
-    redirectTo: "/progression/high-scores",
-    pathMatch: "full",
-  },
-  {
-    path: "progression/high-scores",
     loadComponent: () =>
       import("./components/progression/high-scores/high-scores").then(
         (m) => m.HighScores,

--- a/src/app/components/buttons/back-button.spec.ts
+++ b/src/app/components/buttons/back-button.spec.ts
@@ -1,0 +1,49 @@
+import { provideZonelessChangeDetection } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { describe, test, expect, beforeEach, vi } from "vitest";
+
+import { BackButton } from "./back-button";
+
+describe("BackButton", () => {
+  let fixture: ComponentFixture<BackButton>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(BackButton);
+  });
+
+  test("renders default aria-label when none provided", () => {
+    fixture.detectChanges();
+
+    const button = (fixture.nativeElement as HTMLElement).querySelector(
+      "button",
+    );
+    expect(button?.getAttribute("aria-label")).toBe("Back");
+  });
+
+  test("renders provided aria-label", () => {
+    fixture.componentRef.setInput("ariaLabel", "Back to menu");
+    fixture.detectChanges();
+
+    const button = (fixture.nativeElement as HTMLElement).querySelector(
+      'button[aria-label="Back to menu"]',
+    );
+    expect(button).not.toBeNull();
+  });
+
+  test("emits clicked when pressed", () => {
+    const handler = vi.fn();
+    fixture.componentRef.instance.clicked.subscribe(handler);
+    fixture.detectChanges();
+
+    const button = (fixture.nativeElement as HTMLElement).querySelector(
+      "button",
+    );
+    button?.click();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/components/buttons/back-button.ts
+++ b/src/app/components/buttons/back-button.ts
@@ -1,0 +1,23 @@
+import { Component, input, output } from "@angular/core";
+import { faAngleLeft } from "@awesome.me/kit-fa99832706/icons/slab/regular";
+import { FaIconComponent } from "@fortawesome/angular-fontawesome";
+
+@Component({
+  selector: "app-back-button",
+  imports: [FaIconComponent],
+  template: `
+    <button
+      type="button"
+      (click)="clicked.emit()"
+      [attr.aria-label]="ariaLabel()"
+      class="flex h-10 w-10 items-center justify-center rounded-full bg-white/30 text-xl font-bold text-black backdrop-blur-sm transition-all duration-200 hover:scale-105 hover:bg-white/50 active:scale-95"
+    >
+      <fa-icon [icon]="faAngleLeft" />
+    </button>
+  `,
+})
+export class BackButton {
+  readonly ariaLabel = input<string>("Back");
+  readonly clicked = output();
+  protected readonly faAngleLeft = faAngleLeft;
+}

--- a/src/app/components/main-menu/main-menu.ts
+++ b/src/app/components/main-menu/main-menu.ts
@@ -157,10 +157,9 @@ export class MainMenu implements OnInit {
       },
       {
         id: "progression",
-        label: "Journey",
+        label: "High Scores",
         icon: faSignalBars,
-        route: "/progression",
-        disabled: true,
+        route: "/progression/high-scores",
       },
       {
         id: "challenges",

--- a/src/app/components/main-menu/main-menu.ts
+++ b/src/app/components/main-menu/main-menu.ts
@@ -157,9 +157,9 @@ export class MainMenu implements OnInit {
       },
       {
         id: "progression",
-        label: "High Scores",
+        label: "Progression",
         icon: faSignalBars,
-        route: "/progression/high-scores",
+        route: "/progression",
       },
       {
         id: "challenges",

--- a/src/app/components/progression/high-scores/high-scores.spec.ts
+++ b/src/app/components/progression/high-scores/high-scores.spec.ts
@@ -1,0 +1,114 @@
+import {
+  provideZonelessChangeDetection,
+  signal,
+  WritableSignal,
+} from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { Router } from "@angular/router";
+import { describe, test, expect, beforeEach, vi } from "vitest";
+
+import { AudioService } from "../../../audio/audio.service";
+import { PlayerStats, Progression } from "../../../services/progression";
+
+import { HighScores } from "./high-scores";
+
+const emptyStats: PlayerStats = {
+  gamesPlayed: 0,
+  totalScore: 0,
+  highScore: 0,
+  totalLength: 0,
+  longestSnake: 0,
+  perfectGames: 0,
+  playTime: 0,
+};
+
+describe("HighScores", () => {
+  let fixture: ComponentFixture<HighScores>;
+  let component: HighScores;
+  let playerStats: WritableSignal<PlayerStats>;
+  let routerNavigate: ReturnType<typeof vi.fn>;
+  let audioPlaySfx: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    playerStats = signal<PlayerStats>(emptyStats);
+    routerNavigate = vi.fn().mockResolvedValue(true);
+    audioPlaySfx = vi.fn();
+
+    await TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        { provide: Progression, useValue: { playerStats } },
+        { provide: AudioService, useValue: { playSfx: audioPlaySfx } },
+        { provide: Router, useValue: { navigate: routerNavigate } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HighScores);
+    component = fixture.componentInstance;
+  });
+
+  test("creates the component", () => {
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  test("renders empty state when no games have been played", () => {
+    fixture.detectChanges();
+
+    const text = (fixture.nativeElement as HTMLElement).textContent ?? "";
+    expect(text).toContain("Play your first game");
+    expect(text).not.toContain("Best Score");
+  });
+
+  test("renders all stats when populated", () => {
+    playerStats.set({
+      gamesPlayed: 7,
+      totalScore: 420,
+      highScore: 99,
+      totalLength: 130,
+      longestSnake: 42,
+      perfectGames: 2,
+      playTime: 3725,
+    });
+
+    fixture.detectChanges();
+
+    const text = (fixture.nativeElement as HTMLElement).textContent ?? "";
+    expect(text).toContain("Best Score");
+    expect(text).toContain("99");
+    expect(text).toContain("Longest Snake");
+    expect(text).toContain("42");
+    expect(text).toContain("Games Played");
+    expect(text).toContain("7");
+    expect(text).toContain("Play Time");
+    expect(text).toContain("1h 2m");
+    expect(text).toContain("Total Length");
+    expect(text).toContain("130");
+    expect(text).toContain("Perfect Games");
+    expect(text).toContain("2");
+    expect(text).not.toContain("Play your first game");
+  });
+
+  test("back button navigates to /menu and plays click sfx", () => {
+    playerStats.set({
+      gamesPlayed: 1,
+      totalScore: 10,
+      highScore: 10,
+      totalLength: 5,
+      longestSnake: 5,
+      perfectGames: 0,
+      playTime: 30,
+    });
+
+    fixture.detectChanges();
+
+    const button = (fixture.nativeElement as HTMLElement).querySelector(
+      'button[aria-label="Back to menu"]',
+    ) as HTMLButtonElement | null;
+    expect(button).not.toBeNull();
+    button?.click();
+
+    expect(audioPlaySfx).toHaveBeenCalled();
+    expect(routerNavigate).toHaveBeenCalledWith(["/menu"]);
+  });
+});

--- a/src/app/components/progression/high-scores/high-scores.spec.ts
+++ b/src/app/components/progression/high-scores/high-scores.spec.ts
@@ -54,7 +54,7 @@ describe("HighScores", () => {
   test("renders empty state when no games have been played", () => {
     fixture.detectChanges();
 
-    const text = (fixture.nativeElement as HTMLElement).textContent ?? "";
+    const text = (fixture.nativeElement as HTMLElement).textContent;
     expect(text).toContain("Play your first game");
     expect(text).not.toContain("Best Score");
   });
@@ -71,7 +71,7 @@ describe("HighScores", () => {
 
     fixture.detectChanges();
 
-    const text = (fixture.nativeElement as HTMLElement).textContent ?? "";
+    const text = (fixture.nativeElement as HTMLElement).textContent;
     expect(text).toContain("Best Score");
     expect(text).toContain("99");
     expect(text).toContain("Longest Snake");
@@ -99,9 +99,9 @@ describe("HighScores", () => {
 
     const button = (fixture.nativeElement as HTMLElement).querySelector(
       'button[aria-label="Back to menu"]',
-    ) as HTMLButtonElement | null;
+    );
     expect(button).not.toBeNull();
-    button?.click();
+    (button as HTMLButtonElement | null)?.click();
 
     expect(audioPlaySfx).toHaveBeenCalled();
     expect(routerNavigate).toHaveBeenCalledWith(["/menu"]);

--- a/src/app/components/progression/high-scores/high-scores.spec.ts
+++ b/src/app/components/progression/high-scores/high-scores.spec.ts
@@ -18,7 +18,6 @@ const emptyStats: PlayerStats = {
   highScore: 0,
   totalLength: 0,
   longestSnake: 0,
-  perfectGames: 0,
   playTime: 0,
 };
 
@@ -67,7 +66,6 @@ describe("HighScores", () => {
       highScore: 99,
       totalLength: 130,
       longestSnake: 42,
-      perfectGames: 2,
       playTime: 3725,
     });
 
@@ -84,8 +82,6 @@ describe("HighScores", () => {
     expect(text).toContain("1h 2m");
     expect(text).toContain("Total Length");
     expect(text).toContain("130");
-    expect(text).toContain("Perfect Games");
-    expect(text).toContain("2");
     expect(text).not.toContain("Play your first game");
   });
 
@@ -96,7 +92,6 @@ describe("HighScores", () => {
       highScore: 10,
       totalLength: 5,
       longestSnake: 5,
-      perfectGames: 0,
       playTime: 30,
     });
 

--- a/src/app/components/progression/high-scores/high-scores.ts
+++ b/src/app/components/progression/high-scores/high-scores.ts
@@ -8,9 +8,11 @@ import { SfxType } from "../../../audio/sfx";
 import { Progression } from "../../../services/progression";
 import { FluidContainer } from "../../containers/fluid-container";
 
+import { StatCard } from "./stat-card";
+
 @Component({
   selector: "app-high-scores",
-  imports: [FaIconComponent, FluidContainer],
+  imports: [FaIconComponent, FluidContainer, StatCard],
   template: `
     <app-fluid-container
       class="font-gorditas from-primary to-secondary bg-linear-to-br/srgb"
@@ -20,7 +22,7 @@ import { FluidContainer } from "../../containers/fluid-container";
           <button
             (click)="goBack()"
             aria-label="Back to menu"
-            class="flex h-10 w-10 transform items-center justify-center rounded-full bg-white/30 text-xl font-bold text-black backdrop-blur-sm transition-all duration-200 hover:scale-105 hover:bg-white/50 active:scale-95"
+            class="flex h-10 w-10 items-center justify-center rounded-full bg-white/30 text-xl font-bold text-black backdrop-blur-sm transition-all duration-200 hover:scale-105 hover:bg-white/50 active:scale-95"
           >
             <fa-icon [icon]="faAngleLeft" />
           </button>
@@ -29,7 +31,9 @@ import { FluidContainer } from "../../containers/fluid-container";
           </h1>
         </div>
 
-        @if (isEmpty()) {
+        @let s = stats();
+
+        @if (s.gamesPlayed === 0) {
           <div
             class="flex flex-1 flex-col items-center justify-center text-center"
           >
@@ -44,36 +48,15 @@ import { FluidContainer } from "../../containers/fluid-container";
           </div>
         } @else {
           <div class="grid grid-cols-2 gap-3 text-black sm:gap-4">
-            <div
-              class="col-span-2 flex flex-col items-center rounded-2xl bg-white/20 p-4 text-center backdrop-blur-sm"
-            >
-              <div class="text-3xl font-bold">{{ stats().longestSnake }}</div>
-              <div class="mt-1 text-sm opacity-75">Longest Snake</div>
-            </div>
-            <div
-              class="flex flex-col items-center rounded-2xl bg-white/20 p-4 text-center backdrop-blur-sm"
-            >
-              <div class="text-3xl font-bold">{{ stats().highScore }}</div>
-              <div class="mt-1 text-sm opacity-75">Best Score</div>
-            </div>
-            <div
-              class="flex flex-col items-center rounded-2xl bg-white/20 p-4 text-center backdrop-blur-sm"
-            >
-              <div class="text-3xl font-bold">{{ stats().gamesPlayed }}</div>
-              <div class="mt-1 text-sm opacity-75">Games Played</div>
-            </div>
-            <div
-              class="flex flex-col items-center rounded-2xl bg-white/20 p-4 text-center backdrop-blur-sm"
-            >
-              <div class="text-3xl font-bold">{{ playTimeLabel() }}</div>
-              <div class="mt-1 text-sm opacity-75">Play Time</div>
-            </div>
-            <div
-              class="flex flex-col items-center rounded-2xl bg-white/20 p-4 text-center backdrop-blur-sm"
-            >
-              <div class="text-3xl font-bold">{{ stats().totalLength }}</div>
-              <div class="mt-1 text-sm opacity-75">Total Length</div>
-            </div>
+            <app-stat-card
+              [value]="s.longestSnake"
+              label="Longest Snake"
+              [highlight]="true"
+            />
+            <app-stat-card [value]="s.highScore" label="Best Score" />
+            <app-stat-card [value]="s.gamesPlayed" label="Games Played" />
+            <app-stat-card [value]="playTimeLabel()" label="Play Time" />
+            <app-stat-card [value]="s.totalLength" label="Total Length" />
           </div>
         }
       </div>
@@ -88,7 +71,6 @@ export class HighScores {
   readonly faAngleLeft = faAngleLeft;
 
   readonly stats = this.#progression.playerStats;
-  readonly isEmpty = computed(() => this.stats().gamesPlayed === 0);
   readonly playTimeLabel = computed(() =>
     formatPlayTime(this.stats().playTime),
   );
@@ -100,11 +82,11 @@ export class HighScores {
 }
 
 function formatPlayTime(totalSeconds: number): string {
-  if (totalSeconds <= 0) return "0m";
-  const hours = Math.floor(totalSeconds / 3600);
-  const minutes = Math.floor((totalSeconds % 3600) / 60);
-  const seconds = Math.floor(totalSeconds % 60);
+  const s = Math.max(0, Math.floor(totalSeconds));
+  const hours = Math.floor(s / 3600);
+  const minutes = Math.floor((s % 3600) / 60);
   if (hours > 0) return `${hours.toString()}h ${minutes.toString()}m`;
+  const seconds = s % 60;
   if (minutes > 0) return `${minutes.toString()}m ${seconds.toString()}s`;
   return `${seconds.toString()}s`;
 }

--- a/src/app/components/progression/high-scores/high-scores.ts
+++ b/src/app/components/progression/high-scores/high-scores.ts
@@ -45,16 +45,16 @@ import { FluidContainer } from "../../containers/fluid-container";
         } @else {
           <div class="grid grid-cols-2 gap-3 text-black sm:gap-4">
             <div
-              class="flex flex-col items-center rounded-2xl bg-white/20 p-4 text-center backdrop-blur-sm"
+              class="col-span-2 flex flex-col items-center rounded-2xl bg-white/20 p-4 text-center backdrop-blur-sm"
             >
-              <div class="text-3xl font-bold">{{ stats().highScore }}</div>
-              <div class="mt-1 text-sm opacity-75">Best Score</div>
+              <div class="text-3xl font-bold">{{ stats().longestSnake }}</div>
+              <div class="mt-1 text-sm opacity-75">Longest Snake</div>
             </div>
             <div
               class="flex flex-col items-center rounded-2xl bg-white/20 p-4 text-center backdrop-blur-sm"
             >
-              <div class="text-3xl font-bold">{{ stats().longestSnake }}</div>
-              <div class="mt-1 text-sm opacity-75">Longest Snake</div>
+              <div class="text-3xl font-bold">{{ stats().highScore }}</div>
+              <div class="mt-1 text-sm opacity-75">Best Score</div>
             </div>
             <div
               class="flex flex-col items-center rounded-2xl bg-white/20 p-4 text-center backdrop-blur-sm"
@@ -69,7 +69,7 @@ import { FluidContainer } from "../../containers/fluid-container";
               <div class="mt-1 text-sm opacity-75">Play Time</div>
             </div>
             <div
-              class="col-span-2 flex flex-col items-center rounded-2xl bg-white/20 p-4 text-center backdrop-blur-sm"
+              class="flex flex-col items-center rounded-2xl bg-white/20 p-4 text-center backdrop-blur-sm"
             >
               <div class="text-3xl font-bold">{{ stats().totalLength }}</div>
               <div class="mt-1 text-sm opacity-75">Total Length</div>

--- a/src/app/components/progression/high-scores/high-scores.ts
+++ b/src/app/components/progression/high-scores/high-scores.ts
@@ -1,31 +1,28 @@
 import { Component, computed, inject } from "@angular/core";
 import { Router } from "@angular/router";
-import { faAngleLeft } from "@awesome.me/kit-fa99832706/icons/slab/regular";
-import { FaIconComponent } from "@fortawesome/angular-fontawesome";
 
 import { AudioService } from "../../../audio/audio.service";
 import { SfxType } from "../../../audio/sfx";
 import { Progression } from "../../../services/progression";
+import { BackButton } from "../../buttons/back-button";
 import { FluidContainer } from "../../containers/fluid-container";
 
 import { StatCard } from "./stat-card";
 
 @Component({
   selector: "app-high-scores",
-  imports: [FaIconComponent, FluidContainer, StatCard],
+  imports: [BackButton, FluidContainer, StatCard],
   template: `
     <app-fluid-container
       class="font-gorditas from-primary to-secondary bg-linear-to-br/srgb"
     >
       <div class="flex h-full flex-col p-6">
-        <div class="mb-6 flex items-center gap-3">
-          <button
-            (click)="goBack()"
-            aria-label="Back to menu"
-            class="flex h-10 w-10 items-center justify-center rounded-full bg-white/30 text-xl font-bold text-black backdrop-blur-sm transition-all duration-200 hover:scale-105 hover:bg-white/50 active:scale-95"
-          >
-            <fa-icon [icon]="faAngleLeft" />
-          </button>
+        <div class="relative mb-6 flex items-center justify-center">
+          <app-back-button
+            class="absolute left-0"
+            ariaLabel="Back to menu"
+            (clicked)="goBack()"
+          />
           <h1 class="text-3xl font-bold text-black drop-shadow-lg sm:text-4xl">
             High Scores
           </h1>
@@ -67,8 +64,6 @@ export class HighScores {
   readonly #router = inject(Router);
   readonly #progression = inject(Progression);
   readonly #audio = inject(AudioService);
-
-  readonly faAngleLeft = faAngleLeft;
 
   readonly stats = this.#progression.playerStats;
   readonly playTimeLabel = computed(() =>

--- a/src/app/components/progression/high-scores/high-scores.ts
+++ b/src/app/components/progression/high-scores/high-scores.ts
@@ -1,5 +1,7 @@
 import { Component, computed, inject } from "@angular/core";
 import { Router } from "@angular/router";
+import { faAngleLeft } from "@awesome.me/kit-fa99832706/icons/slab/regular";
+import { FaIconComponent } from "@fortawesome/angular-fontawesome";
 
 import { AudioService } from "../../../audio/audio.service";
 import { SfxType } from "../../../audio/sfx";
@@ -8,30 +10,26 @@ import { FluidContainer } from "../../containers/fluid-container";
 
 @Component({
   selector: "app-high-scores",
-  imports: [FluidContainer],
+  imports: [FaIconComponent, FluidContainer],
   template: `
     <app-fluid-container
       class="font-gorditas from-primary to-secondary bg-linear-to-br/srgb"
     >
       <div class="flex h-full flex-col p-6">
-        <!-- Header -->
         <div class="mb-6 flex items-center gap-3">
           <button
             (click)="goBack()"
             aria-label="Back to menu"
             class="flex h-10 w-10 transform items-center justify-center rounded-full bg-white/30 text-xl font-bold text-black backdrop-blur-sm transition-all duration-200 hover:scale-105 hover:bg-white/50 active:scale-95"
           >
-            &larr;
+            <fa-icon [icon]="faAngleLeft" />
           </button>
-          <h1
-            class="text-3xl font-bold text-black drop-shadow-lg sm:text-4xl"
-          >
+          <h1 class="text-3xl font-bold text-black drop-shadow-lg sm:text-4xl">
             High Scores
           </h1>
         </div>
 
         @if (isEmpty()) {
-          <!-- Empty state -->
           <div
             class="flex flex-1 flex-col items-center justify-center text-center"
           >
@@ -45,7 +43,6 @@ import { FluidContainer } from "../../containers/fluid-container";
             </div>
           </div>
         } @else {
-          <!-- Stats grid -->
           <div class="grid grid-cols-2 gap-3 text-black sm:gap-4">
             <div
               class="flex flex-col items-center rounded-2xl bg-white/20 p-4 text-center backdrop-blur-sm"
@@ -72,16 +69,10 @@ import { FluidContainer } from "../../containers/fluid-container";
               <div class="mt-1 text-sm opacity-75">Play Time</div>
             </div>
             <div
-              class="flex flex-col items-center rounded-2xl bg-white/20 p-4 text-center backdrop-blur-sm"
+              class="col-span-2 flex flex-col items-center rounded-2xl bg-white/20 p-4 text-center backdrop-blur-sm"
             >
               <div class="text-3xl font-bold">{{ stats().totalLength }}</div>
               <div class="mt-1 text-sm opacity-75">Total Length</div>
-            </div>
-            <div
-              class="flex flex-col items-center rounded-2xl bg-white/20 p-4 text-center backdrop-blur-sm"
-            >
-              <div class="text-3xl font-bold">{{ stats().perfectGames }}</div>
-              <div class="mt-1 text-sm opacity-75">Perfect Games</div>
             </div>
           </div>
         }
@@ -93,6 +84,8 @@ export class HighScores {
   readonly #router = inject(Router);
   readonly #progression = inject(Progression);
   readonly #audio = inject(AudioService);
+
+  readonly faAngleLeft = faAngleLeft;
 
   readonly stats = this.#progression.playerStats;
   readonly isEmpty = computed(() => this.stats().gamesPlayed === 0);

--- a/src/app/components/progression/high-scores/high-scores.ts
+++ b/src/app/components/progression/high-scores/high-scores.ts
@@ -1,0 +1,117 @@
+import { Component, computed, inject } from "@angular/core";
+import { Router } from "@angular/router";
+
+import { AudioService } from "../../../audio/audio.service";
+import { SfxType } from "../../../audio/sfx";
+import { Progression } from "../../../services/progression";
+import { FluidContainer } from "../../containers/fluid-container";
+
+@Component({
+  selector: "app-high-scores",
+  imports: [FluidContainer],
+  template: `
+    <app-fluid-container
+      class="font-gorditas from-primary to-secondary bg-linear-to-br/srgb"
+    >
+      <div class="flex h-full flex-col p-6">
+        <!-- Header -->
+        <div class="mb-6 flex items-center gap-3">
+          <button
+            (click)="goBack()"
+            aria-label="Back to menu"
+            class="flex h-10 w-10 transform items-center justify-center rounded-full bg-white/30 text-xl font-bold text-black backdrop-blur-sm transition-all duration-200 hover:scale-105 hover:bg-white/50 active:scale-95"
+          >
+            &larr;
+          </button>
+          <h1
+            class="text-3xl font-bold text-black drop-shadow-lg sm:text-4xl"
+          >
+            High Scores
+          </h1>
+        </div>
+
+        @if (isEmpty()) {
+          <!-- Empty state -->
+          <div
+            class="flex flex-1 flex-col items-center justify-center text-center"
+          >
+            <div
+              class="rounded-2xl bg-white/20 p-8 text-black backdrop-blur-sm"
+            >
+              <h2 class="mb-2 text-2xl font-semibold">No stats yet</h2>
+              <p class="opacity-80">
+                Play your first game to start your journey!
+              </p>
+            </div>
+          </div>
+        } @else {
+          <!-- Stats grid -->
+          <div class="grid grid-cols-2 gap-3 text-black sm:gap-4">
+            <div
+              class="flex flex-col items-center rounded-2xl bg-white/20 p-4 text-center backdrop-blur-sm"
+            >
+              <div class="text-3xl font-bold">{{ stats().highScore }}</div>
+              <div class="mt-1 text-sm opacity-75">Best Score</div>
+            </div>
+            <div
+              class="flex flex-col items-center rounded-2xl bg-white/20 p-4 text-center backdrop-blur-sm"
+            >
+              <div class="text-3xl font-bold">{{ stats().longestSnake }}</div>
+              <div class="mt-1 text-sm opacity-75">Longest Snake</div>
+            </div>
+            <div
+              class="flex flex-col items-center rounded-2xl bg-white/20 p-4 text-center backdrop-blur-sm"
+            >
+              <div class="text-3xl font-bold">{{ stats().gamesPlayed }}</div>
+              <div class="mt-1 text-sm opacity-75">Games Played</div>
+            </div>
+            <div
+              class="flex flex-col items-center rounded-2xl bg-white/20 p-4 text-center backdrop-blur-sm"
+            >
+              <div class="text-3xl font-bold">{{ playTimeLabel() }}</div>
+              <div class="mt-1 text-sm opacity-75">Play Time</div>
+            </div>
+            <div
+              class="flex flex-col items-center rounded-2xl bg-white/20 p-4 text-center backdrop-blur-sm"
+            >
+              <div class="text-3xl font-bold">{{ stats().totalLength }}</div>
+              <div class="mt-1 text-sm opacity-75">Total Length</div>
+            </div>
+            <div
+              class="flex flex-col items-center rounded-2xl bg-white/20 p-4 text-center backdrop-blur-sm"
+            >
+              <div class="text-3xl font-bold">{{ stats().perfectGames }}</div>
+              <div class="mt-1 text-sm opacity-75">Perfect Games</div>
+            </div>
+          </div>
+        }
+      </div>
+    </app-fluid-container>
+  `,
+})
+export class HighScores {
+  readonly #router = inject(Router);
+  readonly #progression = inject(Progression);
+  readonly #audio = inject(AudioService);
+
+  readonly stats = this.#progression.playerStats;
+  readonly isEmpty = computed(() => this.stats().gamesPlayed === 0);
+  readonly playTimeLabel = computed(() =>
+    formatPlayTime(this.stats().playTime),
+  );
+
+  goBack(): void {
+    this.#audio.playSfx(SfxType.UiClick);
+    void this.#router.navigate(["/menu"]);
+  }
+}
+
+function formatPlayTime(totalSeconds: number): string {
+  if (totalSeconds <= 0) return "0m";
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = Math.floor(totalSeconds % 60);
+  if (hours > 0) return `${hours.toString()}h ${minutes.toString()}m`;
+  if (minutes > 0) return `${minutes.toString()}m ${seconds.toString()}s`;
+  return `${seconds.toString()}s`;
+}

--- a/src/app/components/progression/high-scores/stat-card.ts
+++ b/src/app/components/progression/high-scores/stat-card.ts
@@ -1,0 +1,19 @@
+import { Component, input } from "@angular/core";
+
+@Component({
+  selector: "app-stat-card",
+  template: `
+    <div class="text-3xl font-bold">{{ value() }}</div>
+    <div class="mt-1 text-sm opacity-75">{{ label() }}</div>
+  `,
+  host: {
+    class:
+      "flex flex-col items-center rounded-2xl bg-white/20 p-4 text-center backdrop-blur-sm",
+    "[class.col-span-2]": "highlight()",
+  },
+})
+export class StatCard {
+  readonly value = input.required<string | number>();
+  readonly label = input.required<string>();
+  readonly highlight = input(false);
+}

--- a/src/app/services/progression.ts
+++ b/src/app/services/progression.ts
@@ -113,7 +113,8 @@ export class Progression {
 
   // Progression management
   updateStats(update: UpdatePlayerStats): void {
-    this.playerStats.update((current) => ({
+    const current = this.playerStats();
+    const next: PlayerStats = {
       ...current,
       gamesPlayed: current.gamesPlayed + 1,
       highScore: Math.max(current.highScore, update.currentScore),
@@ -121,14 +122,15 @@ export class Progression {
       playTime: current.playTime + update.playTime,
       totalLength: current.totalLength + update.currentLength,
       totalScore: current.totalScore + update.currentScore,
-    }));
+    };
+    this.playerStats.set(next);
 
-    this.#store.write(StoreKey.HighScore, this.playerStats().highScore);
-    this.#store.write(StoreKey.GamesPlayed, this.playerStats().gamesPlayed);
-    this.#store.write(StoreKey.TotalScore, this.playerStats().totalScore);
-    this.#store.write(StoreKey.TotalLength, this.playerStats().totalLength);
-    this.#store.write(StoreKey.LongestSnake, this.playerStats().longestSnake);
-    this.#store.write(StoreKey.PlayTime, this.playerStats().playTime);
+    this.#store.write(StoreKey.HighScore, next.highScore);
+    this.#store.write(StoreKey.GamesPlayed, next.gamesPlayed);
+    this.#store.write(StoreKey.TotalScore, next.totalScore);
+    this.#store.write(StoreKey.TotalLength, next.totalLength);
+    this.#store.write(StoreKey.LongestSnake, next.longestSnake);
+    this.#store.write(StoreKey.PlayTime, next.playTime);
   }
 
   unlockMap(mapId: string): void {

--- a/src/app/services/progression.ts
+++ b/src/app/services/progression.ts
@@ -21,6 +21,7 @@ export interface PlayerStats {
   totalScore: number;
   highScore: number;
   totalLength: number;
+  longestSnake: number;
   perfectGames: number;
   playTime: number; // in seconds
 }
@@ -47,6 +48,7 @@ export class Progression {
     totalScore: 0,
     highScore: 0,
     totalLength: 0,
+    longestSnake: 0,
     perfectGames: 0,
     playTime: 0,
   });
@@ -117,6 +119,7 @@ export class Progression {
       ...current,
       gamesPlayed: current.gamesPlayed + 1,
       highScore: Math.max(current.highScore, update.currentScore),
+      longestSnake: Math.max(current.longestSnake, update.currentLength),
       playTime: current.playTime + update.playTime,
       totalLength: current.totalLength + update.currentLength,
       totalScore: current.totalScore + update.currentScore,
@@ -126,6 +129,7 @@ export class Progression {
     this.#store.write(StoreKey.GamesPlayed, this.playerStats().gamesPlayed);
     this.#store.write(StoreKey.TotalScore, this.playerStats().totalScore);
     this.#store.write(StoreKey.TotalLength, this.playerStats().totalLength);
+    this.#store.write(StoreKey.LongestSnake, this.playerStats().longestSnake);
     this.#store.write(StoreKey.PerfectGames, this.playerStats().perfectGames);
     this.#store.write(StoreKey.PlayTime, this.playerStats().playTime);
   }
@@ -208,6 +212,7 @@ export class Progression {
         totalScore: this.#store.totalScore() ?? 0,
         highScore: this.#store.highScore() ?? 0,
         totalLength: this.#store.totalLength() ?? 0,
+        longestSnake: this.#store.longestSnake() ?? 0,
         perfectGames: this.#store.perfectGames() ?? 0,
         playTime: this.#store.playTime() ?? 0,
       }));

--- a/src/app/services/progression.ts
+++ b/src/app/services/progression.ts
@@ -22,7 +22,6 @@ export interface PlayerStats {
   highScore: number;
   totalLength: number;
   longestSnake: number;
-  perfectGames: number;
   playTime: number; // in seconds
 }
 
@@ -49,7 +48,6 @@ export class Progression {
     highScore: 0,
     totalLength: 0,
     longestSnake: 0,
-    perfectGames: 0,
     playTime: 0,
   });
 
@@ -130,7 +128,6 @@ export class Progression {
     this.#store.write(StoreKey.TotalScore, this.playerStats().totalScore);
     this.#store.write(StoreKey.TotalLength, this.playerStats().totalLength);
     this.#store.write(StoreKey.LongestSnake, this.playerStats().longestSnake);
-    this.#store.write(StoreKey.PerfectGames, this.playerStats().perfectGames);
     this.#store.write(StoreKey.PlayTime, this.playerStats().playTime);
   }
 
@@ -213,7 +210,6 @@ export class Progression {
         highScore: this.#store.highScore() ?? 0,
         totalLength: this.#store.totalLength() ?? 0,
         longestSnake: this.#store.longestSnake() ?? 0,
-        perfectGames: this.#store.perfectGames() ?? 0,
         playTime: this.#store.playTime() ?? 0,
       }));
     });

--- a/src/app/services/storage/data.ts
+++ b/src/app/services/storage/data.ts
@@ -7,6 +7,7 @@ export enum StoreKey {
   GamesPlayed = "gamesPlayed",
   TotalScore = "totalScore",
   TotalLength = "totalLength",
+  LongestSnake = "longestSnake",
   PerfectGames = "perfectGames",
   PlayTime = "playTime",
   NoodleCoins = "noodleCoins",
@@ -41,6 +42,7 @@ export interface HungryStore {
   [StoreKey.GamesPlayed]?: number;
   [StoreKey.TotalScore]?: number;
   [StoreKey.TotalLength]?: number;
+  [StoreKey.LongestSnake]?: number;
   [StoreKey.PerfectGames]?: number;
   [StoreKey.PlayTime]?: number;
   [StoreKey.NoodleCoins]?: number;

--- a/src/app/services/storage/data.ts
+++ b/src/app/services/storage/data.ts
@@ -8,7 +8,6 @@ export enum StoreKey {
   TotalScore = "totalScore",
   TotalLength = "totalLength",
   LongestSnake = "longestSnake",
-  PerfectGames = "perfectGames",
   PlayTime = "playTime",
   NoodleCoins = "noodleCoins",
   GoldenNoodles = "goldenNoodles",
@@ -43,7 +42,6 @@ export interface HungryStore {
   [StoreKey.TotalScore]?: number;
   [StoreKey.TotalLength]?: number;
   [StoreKey.LongestSnake]?: number;
-  [StoreKey.PerfectGames]?: number;
   [StoreKey.PlayTime]?: number;
   [StoreKey.NoodleCoins]?: number;
   [StoreKey.GoldenNoodles]?: number;

--- a/src/app/services/store.ts
+++ b/src/app/services/store.ts
@@ -34,6 +34,9 @@ export class Store {
   readonly totalLength = computed(
     () => this.#store.value()?.[StoreKey.TotalLength],
   );
+  readonly longestSnake = computed(
+    () => this.#store.value()?.[StoreKey.LongestSnake],
+  );
   readonly perfectGames = computed(
     () => this.#store.value()?.[StoreKey.PerfectGames],
   );

--- a/src/app/services/store.ts
+++ b/src/app/services/store.ts
@@ -37,9 +37,6 @@ export class Store {
   readonly longestSnake = computed(
     () => this.#store.value()?.[StoreKey.LongestSnake],
   );
-  readonly perfectGames = computed(
-    () => this.#store.value()?.[StoreKey.PerfectGames],
-  );
   readonly playTime = computed(() => this.#store.value()?.[StoreKey.PlayTime]);
   readonly noodleCoins = computed(
     () => this.#store.value()?.[StoreKey.NoodleCoins],


### PR DESCRIPTION
Builds the first real Progression page wired to existing player stats:
best score, longest snake, games played, play time, total length, perfect
games — with an empty-state for new players. Enables the Main Menu button
that previously redirected back to itself.

Adds StoreKey.LongestSnake and tracks per-game max length in updateStats so
the new "Longest Snake" stat reflects the largest single game rather than a
cumulative total.

Closes #38